### PR TITLE
Add service pages (AI Automation + Contract Development) + Services nav

### DIFF
--- a/src/components/navbar/dropdown.astro
+++ b/src/components/navbar/dropdown.astro
@@ -6,7 +6,7 @@ const { title, lastItem, children } = Astro.props;
 <li class="relative">
   <DropdownContainer class="group">
     <button
-      class="flex items-center gap-1 w-full lg:w-auto lg:px-3 py-2 text-gray-600 hover:text-gray-900">
+      class="flex items-center gap-1 w-full lg:w-auto lg:px-4 py-2 font-mono text-sm text-frost hover:text-white transition-colors duration-200">
       <span>{title}</span>
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -30,12 +30,12 @@ const { title, lastItem, children } = Astro.props;
             : "lg:left-0 origin-top-left",
         ]}>
         <div
-          class="px-3 lg:py-2 lg:bg-white lg:rounded-md lg:shadow lg:border flex flex-col">
+          class="px-3 lg:py-2 lg:bg-navy-800 lg:rounded-md lg:shadow-lg lg:border lg:border-white/[0.06] flex flex-col">
           {
             children.map((item) => (
               <a
                 href={item.path}
-                class="py-1 text-gray-600 hover:text-gray-900">
+                class="py-1 font-mono text-sm text-frost hover:text-white transition-colors duration-200">
                 {item.title}
               </a>
             ))

--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -17,7 +17,7 @@ const menuitems: {
   {
     title: "Services",
     children: [
-      { title: "Contract Development", path: "/services/contract-development" },
+      { title: "Software Development", path: "/services/software-development" },
       { title: "AI Automation", path: "/services/ai-automation" },
     ],
   },

--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -16,7 +16,10 @@ const menuitems: {
   },
   {
     title: "Services",
-    children: [{ title: "AI Automation", path: "/services/ai-automation" }],
+    children: [
+      { title: "Contract Development", path: "/services/contract-development" },
+      { title: "AI Automation", path: "/services/ai-automation" },
+    ],
   },
   {
     title: "About",

--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -6,13 +6,17 @@ import { Astronav, MenuItems, MenuIcon } from "astro-navbar";
 
 const menuitems: {
   title: string;
-  path: string;
+  path?: string;
   badge?: boolean;
   children?: { title: string; path: string }[];
 }[] = [
   {
     title: "Home",
     path: "/",
+  },
+  {
+    title: "Services",
+    children: [{ title: "AI Automation", path: "/services/ai-automation" }],
   },
   {
     title: "About",

--- a/src/components/navbar/navbar.astro
+++ b/src/components/navbar/navbar.astro
@@ -4,12 +4,21 @@ import Link from "@components/ui/link.astro";
 import Dropdown from "./dropdown.astro";
 import { Astronav, MenuItems, MenuIcon } from "astro-navbar";
 
-const menuitems: {
-  title: string;
-  path?: string;
-  badge?: boolean;
-  children?: { title: string; path: string }[];
-}[] = [
+type MenuItem =
+  | {
+      title: string;
+      path: string;
+      badge?: boolean;
+      children?: never;
+    }
+  | {
+      title: string;
+      children: { title: string; path: string }[];
+      badge?: boolean;
+      path?: never;
+    };
+
+const menuitems: MenuItem[] = [
   {
     title: "Home",
     path: "/",

--- a/src/pages/services/ai-automation.astro
+++ b/src/pages/services/ai-automation.astro
@@ -83,7 +83,7 @@ const proof = [
     <!-- What you're really buying -->
     <section class="mt-24 md:mt-32 max-w-3xl">
       <span class="font-mono text-sage-light text-xs uppercase tracking-[0.15em]"
-        >The point</span
+        >&gt; The point</span
       >
       <p class="mt-6 font-display text-2xl md:text-3xl text-white leading-snug">
         You lose hours every week to support tickets, billing, onboarding,
@@ -135,7 +135,7 @@ const proof = [
     <!-- Why me -->
     <section class="mt-24 md:mt-32 max-w-3xl">
       <span class="font-mono text-sage-light text-xs uppercase tracking-[0.15em]"
-        >Why me</span
+        >&gt; Why me</span
       >
       <h2
         class="font-display text-3xl md:text-4xl text-white tracking-tight mt-6">

--- a/src/pages/services/ai-automation.astro
+++ b/src/pages/services/ai-automation.astro
@@ -1,0 +1,162 @@
+---
+import Layout from "@layouts/Layout.astro";
+import Container from "@components/container.astro";
+import Cta from "@components/cta.astro";
+import Link from "@components/ui/link.astro";
+import { Tick } from "@components/ui/icons";
+
+// Copy is clay; Nathan writes the final words.
+const deliverables = [
+  "Support triage & auto-drafted replies",
+  "Billing, dunning & subscription edge cases",
+  "Onboarding & lifecycle automation",
+  "Internal dev tooling: PR triage, CI fixes, codegen",
+  "Reporting, metrics & data pipelines",
+  "Data cleanup & migrations",
+];
+
+const ladder = [
+  {
+    step: "01",
+    name: "Automation Audit",
+    summary:
+      "A fixed-price diagnostic. I find where automation will save you the most time and money, with rough numbers on each. The report is yours to keep even if we stop there.",
+  },
+  {
+    step: "02",
+    name: "First Build",
+    summary:
+      "I build the highest-value automation from the audit, or we build it together if you'd rather. Fixed scope and price, with one clear result. The audit fee comes off the build.",
+  },
+  {
+    step: "03",
+    name: "Ongoing Retainer",
+    summary:
+      "Your automation person on call. I keep things working as the tools change, build new automations, and help you decide what to tackle next. I can run it all for you, or coach your team to own it.",
+  },
+];
+
+const proof = [
+  "TaskRatchet, my own SaaS, runs on billing and ops automation I built",
+  "A pile of open-source dev tooling and Claude Code workflows",
+  "narthbugz, my time-tracking tool, with automated reporting",
+  "Years building automation tools in the Beeminder ecosystem",
+];
+---
+
+<Layout title="AI Automation">
+  <!-- Hero -->
+  <section
+    class="relative bg-gradient-to-b from-navy-800 via-navy-900 to-midnight pt-36 pb-20 md:pt-44 md:pb-28 overflow-hidden">
+    <div
+      class="absolute top-24 left-[20%] w-[420px] h-[320px] bg-navy-600 rounded-full blur-[140px] opacity-30 pointer-events-none"
+      aria-hidden="true">
+    </div>
+    <Container class="relative z-10">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-3 mb-8">
+          <span class="font-mono text-sage-light text-xs uppercase tracking-[0.15em]"
+            >&gt; AI Automation</span
+          >
+          <div class="h-px w-10 bg-sage-light/60"></div>
+        </div>
+        <h1
+          class="font-display text-4xl md:text-5xl lg:text-6xl text-white leading-[1.08] tracking-tight">
+          AI automation that<br />actually keeps working
+        </h1>
+        <p class="mt-8 text-lg md:text-xl text-frost leading-relaxed">
+          I help indie software founders get their time back. I build the
+          automations that handle your busywork and keep them running as the
+          tools underneath them change. I run my own SaaS on the same stack.
+        </p>
+        <div class="mt-10 flex flex-col sm:flex-row gap-4">
+          <Link href="/contact">Start with an audit</Link>
+          <Link href="#how" style="outline">See how it works</Link>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <div class="h-px bg-navy-400/40"></div>
+
+  <Container>
+    <!-- What you're really buying -->
+    <section class="mt-24 md:mt-32 max-w-3xl">
+      <span class="font-mono text-sage-light text-xs uppercase tracking-[0.15em]"
+        >The point</span
+      >
+      <p class="mt-6 font-display text-2xl md:text-3xl text-white leading-snug">
+        You lose hours every week to support tickets, billing, onboarding,
+        reporting, and dev busywork. I automate that work so you get the time
+        back, without having to learn this stuff yourself or hire a full-time
+        engineer.
+      </p>
+    </section>
+
+    <!-- What I can automate -->
+    <section class="mt-24 md:mt-32">
+      <h2 class="font-display text-3xl md:text-4xl text-white tracking-tight">
+        What I can automate
+      </h2>
+      <ul class="grid sm:grid-cols-2 gap-x-10 gap-y-4 mt-10 max-w-4xl">
+        {
+          deliverables.map((item) => (
+            <li class="flex items-start gap-3 text-frost text-lg">
+              <Tick class="w-6 h-6 text-sage shrink-0" />
+              <span>{item}</span>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <!-- How it works (the ladder) -->
+    <section id="how" class="mt-24 md:mt-32 scroll-mt-24">
+      <h2 class="font-display text-3xl md:text-4xl text-white tracking-tight">
+        How it works
+      </h2>
+      <p class="text-lg mt-4 text-frost max-w-2xl">
+        We start with one automation and only keep going if it pays off, so
+        you're never committing to everything up front.
+      </p>
+      <div class="grid md:grid-cols-3 gap-6 mt-12">
+        {
+          ladder.map((rung) => (
+            <div class="border border-white/[0.08] bg-navy-700/30 rounded-lg p-6 flex flex-col">
+              <span class="font-mono text-sage-light text-sm">{rung.step}</span>
+              <h3 class="font-display text-xl text-white mt-3">{rung.name}</h3>
+              <p class="text-frost mt-3 leading-relaxed">{rung.summary}</p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <!-- Why me -->
+    <section class="mt-24 md:mt-32 max-w-3xl">
+      <span class="font-mono text-sage-light text-xs uppercase tracking-[0.15em]"
+        >Why me</span
+      >
+      <h2
+        class="font-display text-3xl md:text-4xl text-white tracking-tight mt-6">
+        I run my own businesses on this
+      </h2>
+      <p class="text-lg mt-4 text-frost leading-relaxed">
+        I'm not selling you a strategy deck. The automation I'd build for you is
+        the same kind already running my own software business.
+      </p>
+      <ul class="grid gap-y-4 mt-8">
+        {
+          proof.map((item) => (
+            <li class="flex items-start gap-3 text-frost text-lg">
+              <Tick class="w-6 h-6 text-sage shrink-0" />
+              <span>{item}</span>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <Cta />
+  </Container>
+</Layout>

--- a/src/pages/services/contract-development.astro
+++ b/src/pages/services/contract-development.astro
@@ -1,0 +1,162 @@
+---
+import Layout from "@layouts/Layout.astro";
+import Container from "@components/container.astro";
+import Cta from "@components/cta.astro";
+import Link from "@components/ui/link.astro";
+import { Tick } from "@components/ui/icons";
+
+// Copy is clay; Nathan writes the final words.
+const deliverables = [
+  "New web apps and features, built full-stack",
+  "APIs, backends, and integrations",
+  "Payments and subscriptions with Stripe",
+  "Membership and course platforms (Memberstack, Webflow)",
+  "Fixing performance, reliability, and billing bugs",
+  "Taking over and stabilizing an existing codebase",
+];
+
+const ladder = [
+  {
+    step: "01",
+    name: "Scope",
+    summary:
+      "We start with a short discovery, then I propose how to run it: hourly or fixed-bid, whichever fits your project, plus what I'll build and when.",
+  },
+  {
+    step: "02",
+    name: "Build",
+    summary:
+      "I ship in small increments you can see, so you're never waiting months to find out what you got.",
+  },
+  {
+    step: "03",
+    name: "Maintain",
+    summary:
+      "Once it's live, I can stay on a monthly retainer to keep it healthy, fix what breaks, and build whatever's next.",
+  },
+];
+
+const proof = [
+  "I run my own SaaS, TaskRatchet, and ship production systems where bugs cost real money",
+  "I do ongoing development on Seedtime, a membership and course platform",
+  "Open-source work like buzz, a Beeminder CLI written in Go",
+  "You work directly with me, not a rotating cast of juniors",
+];
+---
+
+<Layout title="Contract Software Development">
+  <!-- Hero -->
+  <section
+    class="relative bg-gradient-to-b from-navy-800 via-navy-900 to-midnight pt-36 pb-20 md:pt-44 md:pb-28 overflow-hidden">
+    <div
+      class="absolute top-24 left-[20%] w-[420px] h-[320px] bg-navy-600 rounded-full blur-[140px] opacity-30 pointer-events-none"
+      aria-hidden="true">
+    </div>
+    <Container class="relative z-10">
+      <div class="max-w-3xl">
+        <div class="flex items-center gap-3 mb-8">
+          <span class="font-mono text-sage-light text-xs uppercase tracking-[0.15em]"
+            >&gt; Contract Software Development</span
+          >
+          <div class="h-px w-10 bg-sage-light/60"></div>
+        </div>
+        <h1
+          class="font-display text-4xl md:text-5xl lg:text-6xl text-white leading-[1.08] tracking-tight">
+          Software that ships,<br />and keeps shipping
+        </h1>
+        <p class="mt-8 text-lg md:text-xl text-frost leading-relaxed">
+          I build, ship, and maintain web software for founders and small teams.
+          I bill the way that fits the work, hourly or fixed-bid, and I stick
+          around to keep it running after launch.
+        </p>
+        <div class="mt-10 flex flex-col sm:flex-row gap-4">
+          <Link href="/contact">Start a project</Link>
+          <Link href="#how" style="outline">How I work</Link>
+        </div>
+      </div>
+    </Container>
+  </section>
+
+  <div class="h-px bg-navy-400/40"></div>
+
+  <Container>
+    <!-- The point -->
+    <section class="mt-24 md:mt-32 max-w-3xl">
+      <span class="font-mono text-sage-light text-xs uppercase tracking-[0.15em]"
+        >&gt; The point</span
+      >
+      <p class="mt-6 font-display text-2xl md:text-3xl text-white leading-snug">
+        Most contract work is either a junior you have to manage or an agency
+        that disappears after launch. You get a senior developer who scopes the
+        work honestly and ships it in pieces you can see, then stays on to keep
+        it running.
+      </p>
+    </section>
+
+    <!-- What I build -->
+    <section class="mt-24 md:mt-32">
+      <h2 class="font-display text-3xl md:text-4xl text-white tracking-tight">
+        What I build
+      </h2>
+      <ul class="grid sm:grid-cols-2 gap-x-10 gap-y-4 mt-10 max-w-4xl">
+        {
+          deliverables.map((item) => (
+            <li class="flex items-start gap-3 text-frost text-lg">
+              <Tick class="w-6 h-6 text-sage shrink-0" />
+              <span>{item}</span>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <!-- How I work -->
+    <section id="how" class="mt-24 md:mt-32 scroll-mt-24">
+      <h2 class="font-display text-3xl md:text-4xl text-white tracking-tight">
+        How I work
+      </h2>
+      <p class="text-lg mt-4 text-frost max-w-2xl">
+        Scoped up front, shipped in small pieces, with the option to keep me on
+        after launch.
+      </p>
+      <div class="grid md:grid-cols-3 gap-6 mt-12">
+        {
+          ladder.map((rung) => (
+            <div class="border border-white/[0.08] bg-navy-700/30 rounded-lg p-6 flex flex-col">
+              <span class="font-mono text-sage-light text-sm">{rung.step}</span>
+              <h3 class="font-display text-xl text-white mt-3">{rung.name}</h3>
+              <p class="text-frost mt-3 leading-relaxed">{rung.summary}</p>
+            </div>
+          ))
+        }
+      </div>
+    </section>
+
+    <!-- Why me -->
+    <section class="mt-24 md:mt-32 max-w-3xl">
+      <span class="font-mono text-sage-light text-xs uppercase tracking-[0.15em]"
+        >&gt; Why me</span
+      >
+      <h2
+        class="font-display text-3xl md:text-4xl text-white tracking-tight mt-6">
+        I build yours the way I build mine
+      </h2>
+      <p class="text-lg mt-4 text-frost leading-relaxed">
+        I run my own software businesses, so I build for the people who have to
+        live with the thing after launch, the way I build my own.
+      </p>
+      <ul class="grid gap-y-4 mt-8">
+        {
+          proof.map((item) => (
+            <li class="flex items-start gap-3 text-frost text-lg">
+              <Tick class="w-6 h-6 text-sage shrink-0" />
+              <span>{item}</span>
+            </li>
+          ))
+        }
+      </ul>
+    </section>
+
+    <Cta />
+  </Container>
+</Layout>

--- a/src/pages/services/contract-development.astro
+++ b/src/pages/services/contract-development.astro
@@ -40,7 +40,7 @@ const proof = [
   "I run my own SaaS, TaskRatchet, and ship production systems where bugs cost real money",
   "I do ongoing development on Seedtime, a membership and course platform",
   "Open-source work like buzz, a Beeminder CLI written in Go",
-  "You work directly with me, not a rotating cast of juniors",
+  "You work with me directly, and I bring in people I trust when a project needs more hands",
 ];
 ---
 

--- a/src/pages/services/software-development.astro
+++ b/src/pages/services/software-development.astro
@@ -44,7 +44,7 @@ const proof = [
 ];
 ---
 
-<Layout title="Contract Software Development">
+<Layout title="Software Development">
   <!-- Hero -->
   <section
     class="relative bg-gradient-to-b from-navy-800 via-navy-900 to-midnight pt-36 pb-20 md:pt-44 md:pb-28 overflow-hidden">
@@ -56,7 +56,7 @@ const proof = [
       <div class="max-w-3xl">
         <div class="flex items-center gap-3 mb-8">
           <span class="font-mono text-sage-light text-xs uppercase tracking-[0.15em]"
-            >&gt; Contract Software Development</span
+            >&gt; Software Development</span
           >
           <div class="h-px w-10 bg-sage-light/60"></div>
         </div>


### PR DESCRIPTION
## What

Adds the first two per-service pages for Pine Peak Digital and wires them into navigation.

- **`/services/ai-automation`** — productized AI automation offer: hero, value, deliverables, Audit → First Build → Ongoing Retainer ladder (with the done-for-you / done-with-you dial), dogfooding proof.
- **`/services/contract-development`** — build / ship / maintain contract dev for founders and small teams. Flexible billing (hourly or fixed-bid, whichever fits the client). Scope → Build → Maintain engagement.
- **Navbar** — new "Services" dropdown listing both pages. Adding more is a one-line addition to the dropdown's `children`.
- **Dropdown component** — restyled from the leftover Astroship light-theme classes to the site's dark tokens (it had never been used before).

## Notes

- Both pages reuse the site's components (`Layout`/`Container`/`Cta`/`Link`/`Tick`) and dark-theme tokens, and share one structure so they read as a set.
- Copy is a first pass (clay); ran the humanizer over both.
- `astro build` passes (13 pages). Local review loop: no bugs, no a11y blockers, strong convention fit.
- Known follow-ups (not in this PR): advisory-vs-managed headline on the AI page; keep/drop the "support triage" deliverable; optional per-page meta descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)